### PR TITLE
add flag to support standalone executables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,16 @@ set(${PROJECT_NAME}_MAKE_INSTALL ON CACHE BOOL
 set(${PROJECT_NAME}_BUILD_EXAMPLES OFF CACHE BOOL
 	"Set to ON to build examples (default is OFF)")
 
+# Determine stdlib link flags
+if (WIN32)
+	set(DEFAULT_BUILD_STANDALONE ON)
+else()
+	set(DEFAULT_BUILD_STANDALONE OFF)
+endif()
+
+set(BUILD_STANDALONE ${DEFAULT_BUILD_STANDALONE}
+	CACHE BOOL "Set to ON to make the executables as standalone as possible.")
+
 # Check type size
 include(CheckTypeSize)
 check_type_size("int" SIZEOF_INT)

--- a/colm/CMakeLists.txt
+++ b/colm/CMakeLists.txt
@@ -143,6 +143,14 @@ add_executable(colm
 	"${CMAKE_CURRENT_BINARY_DIR}/gen/parse3.c"
 	"${CMAKE_CURRENT_BINARY_DIR}/gen/if3.cc")
 
+if(BUILD_STANDALONE)
+	if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+		target_link_libraries(colm -static)
+	else()
+		message(FATAL_ERROR "Unsupported toolset for standalone build.")
+	endif()
+endif()
+
 target_link_libraries(colm libprog libcolm)
 
 set_property(TARGET colm APPEND PROPERTY

--- a/ragel/CMakeLists.txt
+++ b/ragel/CMakeLists.txt
@@ -27,7 +27,6 @@ set(RUNTIME_HDR
 include(GNUInstallDirs)
 
 # libfsm
-
 add_library(libfsm
 	buffer.h codegen.h
 	actloop.h actexp.h
@@ -59,13 +58,25 @@ set_target_properties(libfsm PROPERTIES
 	OUTPUT_NAME fsm)
 
 # libragel
-
 add_library(libragel
 	# dist
 	parsedata.h parsetree.h inputdata.h pcheck.h reducer.h rlscan.h load.h
 	parsetree.cc longest.cc parsedata.cc inputdata.cc load.cc reducer.cc)
 
-target_link_libraries(libragel colm::libcolm)
+if(BUILD_STANDALONE)
+	# libragel acts as an intermediate library so we can apply
+	# flags we want to apply to all ragel targets to libragel
+	# and they'll automatically propogate. This is a best effort
+	# to get `-static` placed sooner in the link line where it
+	# matters at least.
+	if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+		target_link_libraries(libragel PUBLIC -static)
+	else()
+		message(FATAL_ERROR "Unsupported toolset for standalone build.")
+	endif()
+endif()
+
+target_link_libraries(libragel PRIVATE colm::libcolm)
 
 target_include_directories(libragel
 	PUBLIC


### PR DESCRIPTION
This is a small attempt to add support for building standalone executables, mainly for the benefit of Windows so you don't have to lug around libstdc++, libgcc, and winpthread dlls.

libgcc and libstdc++ fall under the GNU Runtime Library Exception explained here: https://www.gnu.org/licenses/gcc-exception-3.1-faq.en.html

winpthreads does not however. It's license can be found here: https://github.com/mirror/mingw-w64/blob/master/mingw-w64-libraries/winpthreads/COPYING

This works for ragel* and colm, none of the bootstraps are done since I don't think they're significant for distribution.
